### PR TITLE
[DRIFT FIX] Align main with v0.22.34

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,7 @@ inputs:
   version:
     description: "Version of the fastcli binary to use. If 'local', the binary will be used from the path of /tmp/fastci/tools/fastcli-{ARCH}}"
     required: false
-    default: "v0.22.32"
+    default: "v0.22.34"
 
   job_name_for_tests_only:
     description: "Override job name for tests only (used in CI tests)"


### PR DESCRIPTION
## Drift Fix

Aligning `main` branch with release `v0.22.34`.

The tag points to `v0.22.34` but `main` has drifted. This PR brings `main` in sync.

Triggered from the FastCI Release Dashboard.